### PR TITLE
update dependencies: protobuf, Pillow

### DIFF
--- a/custom_components/badconga/manifest.json
+++ b/custom_components/badconga/manifest.json
@@ -8,7 +8,7 @@
       "@adrigzr"
     ],
     "requirements": [
-      "protobuf==3.12.2",
-      "Pillow==7.2.0"
+      "protobuf==3.15.6",
+      "Pillow==8.1.1"
     ]
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 homeassistant==2021.1.5
 Pillow==8.1.1
-protobuf==3.12.2
+protobuf==3.15.6
 voluptuous==0.12.1


### PR DESCRIPTION
bumped:
  - protobuf==3.15.6
  - Pillow==8.1.1

Old version of protobuf prevented start of component.
Old version of Pillow had security issues (which probably didn't affect
this component).